### PR TITLE
Update the apple_reporter.gemspec file

### DIFF
--- a/apple_reporter.gemspec
+++ b/apple_reporter.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency('rest-client')
 
-  spec.add_runtime_dependency 'activesupport', '~> 4.0', '>= 0'
+  spec.add_runtime_dependency 'activesupport', '>= 3.0', '< 6'
 
   spec.add_development_dependency 'bundler', '~> 1.11'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
No need to restrict this gem to Rails 4, all version from 3 to 5 should work.

I have a Rails 3 application which needs this library, I tried locally with this change, and all works as expected.