### PR TITLE
Use access token instead of password

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Or install it yourself as:
 - getReport
 
 ```
-reporter = AppleReporter::Sale.new(user_id: 'your user id', password: 'your password')
+reporter = AppleReporter::Sale.new(user_id: 'your user id', access_token: 'your access token')
 report = reporter.getReport(
   {
     vendor_number: 'your vender id',
@@ -46,7 +46,7 @@ report = reporter.getReport(
 
 - getReport
 ```
-reporter = AppleReporter::Finance.new(user_id: 'your user id', password: 'your password')
+reporter = AppleReporter::Finance.new(user_id: 'your user id', access_token: 'your access token')
 report = reporter.getReport(
   {
     vendor_number: 'your vender id',

--- a/lib/apple_reporter/reporter.rb
+++ b/lib/apple_reporter/reporter.rb
@@ -4,7 +4,7 @@ module AppleReporter
 
     #
     # Usage:
-    # reporter = Apple::Reporter::Sale.new(user_id: 'iscreen', password: 'secret', account: 'myAccount')
+    # reporter = Apple::Reporter::Sale.new(user_id: 'iscreen', access_token: 'secret', account: 'myAccount')
     #
     def initialize(config = {})
       @config = {
@@ -23,7 +23,7 @@ module AppleReporter
       }
       payload = {
         userid: @config[:user_id],
-        password: @config[:password],
+        accesstoken: @config[:access_token],
         version: @config[:version],
         mode: @config[:mode],
         queryInput: "[p=Reporter.properties, #{params}]"

--- a/spec/apple_reporter/finance_spec.rb
+++ b/spec/apple_reporter/finance_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'AppleReporter.Finance' do
   let(:endpoint) { 'https://reportingitc-reporter.apple.com/reportservice/finance/v1'}
-  let(:reporter) { AppleReporter::Finance.new(user_id: 'iscreen', password: 'your password') }
+  let(:reporter) { AppleReporter::Finance.new(user_id: 'iscreen', access_token: 'your access token') }
 
   describe '#getStatus' do
     describe 'successfully' do

--- a/spec/apple_reporter/sale_spec.rb
+++ b/spec/apple_reporter/sale_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'AppleReporter.Sale' do
   let(:endpoint) { 'https://reportingitc-reporter.apple.com/reportservice/sales/v1'}
-  let(:reporter) { AppleReporter::Sale.new(user_id: 'iscreen', password: 'your password') }
+  let(:reporter) { AppleReporter::Sale.new(user_id: 'iscreen', access_token: 'your access token') }
 
   describe '#getAccounts' do
     describe 'successfully' do


### PR DESCRIPTION
Fixes
```
132 - You are required to use your Access Token in your Reporter properties file. You may no longer use your username and password in your Reporter properties file
```

@iscreen 