### PR TITLE
Update apple_reporter.rb

### DIFF
--- a/lib/apple_reporter.rb
+++ b/lib/apple_reporter.rb
@@ -8,5 +8,5 @@ require 'apple_reporter/finance'
 require 'apple_reporter/token'
 
 module AppleReporter
-  raise "Cannot require AppleReporter, unsupported engine '#{RUBY_ENGINE}'" unless RUBY_ENGINE == "ruby"
+  #raise "Cannot require AppleReporter, unsupported engine '#{RUBY_ENGINE}'" unless RUBY_ENGINE == "ruby"
 end


### PR DESCRIPTION
This PR removes the requirement that forbids the usage of JRUBY. I've installed the reporter on jruby with no issues.