### PR TITLE
Fix "undefined method `code' for nil:NilClass"

### DIFF
--- a/lib/apple_reporter/reporter.rb
+++ b/lib/apple_reporter/reporter.rb
@@ -34,7 +34,11 @@ module AppleReporter
       response = RestClient.post("#{ENDPOINT}#{api_path}", "jsonRequest=#{payload.to_json}#{url_params}", headers)
       handle_response(@config[:mode], response)
     rescue RestClient::ExceptionWithResponse => err
-      handle_response(@config[:mode], err.response)
+      if err.response
+        handle_response(@config[:mode], err.response)
+      else
+        raise err
+      end
     end
 
     #


### PR DESCRIPTION
Hi, the err.response is nil when RestClient::Exceptions::Timeout exception happened, so we should raise it and tell user the real exception.